### PR TITLE
Replace outdated broccoli-scss-lint by broccoli-scss-linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var path = require('path')
  , defaults = require('lodash/object/defaults')
  , mergeTrees = require('broccoli-merge-trees')
- , scssLintTree = require('broccoli-scss-lint');
+ , scssLintTree = require('broccoli-scss-linter');
 
 module.exports = {
   name: 'ember-cli-scss-lint',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "broccoli-merge-trees": "^0.2.1",
-    "broccoli-scss-lint": "tomasbasham/broccoli-scss-lint",
+    "broccoli-scss-linter": "^1.0.1",
     "ember-cli-babel": "^5.0.0",
     "lodash": "^3.10.0"
   },

--- a/spec/scss-lint-spec.js
+++ b/spec/scss-lint-spec.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect
- , scssLintTree = require('broccoli-scss-lint');
+ , scssLintTree = require('broccoli-scss-linter');
 
 describe('scss-lint', function() {
   var tree, options;


### PR DESCRIPTION
I've forked outdated [broccoli-scss-lint](https://github.com/a-tarasyuk/broccoli-scss-lint) and republished it as a new package. My fork integrates some fixes (including [yours one](https://github.com/tomasbasham/broccoli-scss-lint/commit/d539e8a590e4d975fa3dcdb8408d0081220314b0)). You can see all changes in [pull requests section](https://github.com/artursmirnov/broccoli-scss-linter/pulls?q=is%3Apr+is%3Aclosed) but the most important is that my fork mutes annoying `Processing` output which becomes overwhelming in big projects.

So this PR integrates my forked package into your Ember CLI addon.