### PR TITLE
Integrate with a new version of broccoli-scss-linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@
 
 var path = require('path')
  , defaults = require('lodash/object/defaults')
- , mergeTrees = require('broccoli-merge-trees')
- , scssLintTree = require('broccoli-scss-linter');
+ , ScssLinter = require('broccoli-scss-linter');
 
 module.exports = {
   name: 'ember-cli-scss-lint',
@@ -47,8 +46,7 @@ module.exports = {
    */
   lintTree: function(treeType, tree) {
     if (treeType === 'app') {
-      var mergedTrees = mergeTrees([this.app.trees.styles]);
-      return scssLintTree(mergedTrees, this.app.options.scssLintOptions);
+      return new ScssLinter([this.app.trees.styles], this.app.options.scssLintOptions);
     }
 
     // There seems to be a bug here where the

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint"
   ],
   "dependencies": {
-    "broccoli-scss-linter": "2.0.1",
+    "broccoli-scss-linter": "2.0.2",
     "ember-cli-babel": "^5.1.5",
     "lodash": "^3.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "lint"
   ],
   "dependencies": {
-    "broccoli-merge-trees": "^0.2.1",
-    "broccoli-scss-linter": "^1.0.1",
+    "broccoli-scss-linter": "2.0.1",
     "ember-cli-babel": "^5.1.5",
     "lodash": "^3.10.0"
   },


### PR DESCRIPTION
I have completely rewritten the `broccoli-scss-linter` in order to improve its performance. Now it runs ~10 times faster for me comparing to previous version.

* I have dropped all unnecessary stuff like formatters, etc. and simplified the code a lot.
* Now it runs against all tree at once instead of running agains each single file.
* Also now it uses new broccoli syntax which requires some changes in the ember addon
* Console output is a bit fine-tuned
* Now it breaks the build in case of error (a rule with `severity: error`)