### PR TITLE
Do not return original tree when not linting.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,5 @@ module.exports = {
 
       return mergeTrees(linted);
     }
-
-    return tree;
   }
 };


### PR DESCRIPTION
The `lintTree` hook is expected to only return a value when it is emitting contents that are different than the input tree (e.g. it emits lint tests). Returning the original input tree results in extra wasted processing (double modules transpilation, extra build work to merge, etc).

FWIW, returning the original raw tree is causing errors in ember-cli@2.13.0 (should be fixed in 2.13.1) see https://github.com/ember-cli/ember-cli/pull/7036.