### PR TITLE
Prevent pass-through `app/**/*.js` in tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var path = require('path')
  , defaults = require('lodash/object/defaults')
  , mergeTrees = require('broccoli-merge-trees')
+ , Funnel = require('broccoli-funnel')
  , ScssLinter = require('broccoli-scss-linter');
 
 module.exports = {
@@ -55,6 +56,7 @@ module.exports = {
       }
 
       var linted = trees.map(function(tree) {
+        let filteredTreeToBeLinted = new Funnel(tree, { exclude: '**/*.js' });
         return new ScssLinter(mergeTrees([tree]), this.scssLintOptions);
       }, this);
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lint"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-scss-linter": "^3.0.0",
     "ember-cli-babel": "^5.1.5",


### PR DESCRIPTION
`broccoli-scss-linter` processes `.scss` and `.sass` files in the provided input trees and convert them into `.sass-lint-test.js` files. Any other files (e.g. `*.js`) files, are "passed through" untouched (this is normal `broccoli-filter`/`broccoli-persistent-filter` behavior).

Unfortunately, the result of this means that any modules in the `app/` tree, end up in **both** `assets/app-name.js` **and** `assets/tests.js` (because `lintTree` results go into `tests.js`).

Prior to ember-cli@2.13, this situation worked fine because we fully transpiled the results of `lintTree`, but as of ember-cli@2.13 we only transpile modules down to AMD (no other transpilation).