### PR TITLE
Fix merge error if there are two files with the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     scssLintOptions: {
-      includedPaths: [
+      includePaths: [
         'vendor'
       ]
     }

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
       }
 
       const linted = trees.map(function(tree) {
-        const filteredTreeToBeLinted = new Funnel(tree, { exclude: ['**/*.js'] });
+        const filteredTreeToBeLinted = new Funnel(tree, { exclude: ['**/*.js'], destDir: tree });
         return new ScssLinter(mergeTrees([filteredTreeToBeLinted]), this.scssLintOptions);
       }, this);
 


### PR DESCRIPTION
I develop an addon which I test with the `tests/dummy/app`. If there is a file with the same name in `addon/styles` and `tests/dummy/app/styles` the build crashes. Just create a file with the name conflict.scss in both directories. The you will see the following exception:
```
Error: Merge error: file styles/conflict.sass-lint-test.js exists in /Users/user/Projects/webclient/tmp/broccoli_merge_trees-input_base_path-pfqHcQSE.tmp/0 and /Users/user/Projects/webclient/tmp/broccoli_merge_trees-input_base_path-pfqHcQSE.tmp/1
Pass option { overwrite: true } to mergeTrees in order to have the latter file win.
```
This pull request tries to fix this issue. I'm not an expert with the broccoli build tool but this fix resolves my issue. I'm not sure if this breaks anything else especially not because I was not able to get the test suite running. Please have a look and let me know what you think 😃  