### PR TITLE
Add `overwrite: true` to resolve conflicting tmp files in build pipeline

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = {
         return new ScssLinter(mergeTrees([filteredTreeToBeLinted]), this.scssLintOptions);
       }, this);
 
-      return mergeTrees(linted);
+      return mergeTrees(linted, { overwrite : true });
     }
   }
 };


### PR DESCRIPTION
Avoids an error on build such as this:
```
Merge error: file .gitkeep exists in /tmp/broccoli-79gqkp3WEAbjbt/out-040-scss_linter and /tmp/broccoli-79gqkp3WEAbjbt/out-044-scss_linter
Pass option { overwrite: true } to mergeTrees in order to have the latter file win.
```